### PR TITLE
Various performance enhancements. Fix #45

### DIFF
--- a/src/CachedInterpolations.jl
+++ b/src/CachedInterpolations.jl
@@ -55,7 +55,7 @@ type CachedInterpolation{T,N,M,O} <: AbstractInterpolation{T,N,BSpline{Quadratic
     tileindex::Int      # equivalent to sub2ind(size(P)[N+1:end], i_1, i_2, ...)
 end
 
-splitN = Base.IteratorsMD.split
+const splitN = Base.IteratorsMD.split
 Base.size{T,N}(itp::CachedInterpolation{T,N})    = splitN(size(itp.parent), Val{N})[1]
 Base.size{T,N}(itp::CachedInterpolation{T,N}, d) = d <= N ? size(itp.parent, d) : 1
 

--- a/src/RegisterOptimize.jl
+++ b/src/RegisterOptimize.jl
@@ -857,7 +857,7 @@ end
 
 function vec2vecϕ{T,N}(Qs::Array{Mat{N,N,T}}, x::AbstractVector{T})
     xf = convert_to_fixed(Vec{N,T}, x, size(Qs))
-    _vec2vecϕ(xf, size(Qs)[1:end-1])
+    _vec2vecϕ(xf, Base.front(size(Qs)))
 end
 
 @noinline function _vec2vecϕ{N}(x::AbstractArray, sz::NTuple{N,Int})


### PR DESCRIPTION
A couple of small tweaks made a big improvement in performance. At least for the test case in #45, there are still places that could be improved, notably in constructing the vector-of-deformations during iterative `cg` steps in `initial_deformation`. However, this may not be the main bottleneck during optimization in more typical conditions, so I don't think it's yet worth worrying about.