### PR TITLE
Install test dependencies manually

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,6 @@ addons:
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
   - julia -e 'Pkg.clone(pwd()); Pkg.build("BlockRegistration")'
+  # Because we circumvent Pkg.test, we have to install test dependencies manually
+  - julia -e 'cd(Pkg.dir("BlockRegistration","test")); if isfile("REQUIRE") reqs = readlines("REQUIRE"); for r in reqs Pkg.add(r) end; end'
   - julia -e 'cd(Pkg.dir("BlockRegistration","test")); use_cuda=false; include("runtests.jl")'


### PR DESCRIPTION
Since we're no longer using `Pkg.test` to run the tests (at least, not until we switch to julia 0.6), we should check for test dependencies. Ref https://github.com/HolyLab/BlockRegistration/pull/54#issuecomment-298819892.