### PR TITLE
Cjg/rigid upgrades

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -20,3 +20,5 @@ Compat 0.44
 ColorTypes
 OffsetArrays
 Optim
+CoordinateTransformations
+Rotations

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -2,6 +2,10 @@ if Base.find_in_path("RFFT") == nothing
     Pkg.clone("git@github.com:HolyLab/RFFT.jl.git")
 end
 
+if Base.find_in_path("QuadDIRECT") == nothing
+    Pkg.clone("git@github.com:timholy/QuadDIRECT.jl.git")
+end
+
 Pkg.checkout("Optim", "teh/constrained")
 lines = cd(Pkg.dir("NLsolve")) do
     readstring(`git remote`)

--- a/src/qd_rigid.jl
+++ b/src/qd_rigid.jl
@@ -1,0 +1,120 @@
+function tfmx(x, img, SD=eye(ndims(img)))
+    if ndims(img) == 2
+        dx, dy, θ = x
+        rotm = RotMatrix(θ)
+        rotm = SD\rotm*SD
+        return Translation(dx, dy) ∘ recenter(SMatrix{2,2}(rotm), center(img))
+    elseif ndims(img) == 3
+        dx, dy, dz, θx, θy, θz =  x
+        rotm = RotMatrix(RotXYZ(θx,θy,θz))
+        rotm = SD\rotm*SD
+        return Translation(dx, dy, dz) ∘ recenter(SMatrix{3,3}(rotm), center(img))
+    else
+        error()
+    end
+end
+
+function rot(theta, img, SD=eye(ndims(img)))
+    if ndims(img) == 2
+        rotm = RotMatrix(theta...)
+        rotm = SD\rotm*SD
+        return recenter(SMatrix{2,2}(rotm), center(img))
+    elseif ndims(img) == 3
+        θx, θy, θz = theta
+        rotm = RotMatrix(RotXYZ(θx,θy,θz))
+        rotm = SD\rotm*SD
+        return recenter(SMatrix{3,3}(rotm), center(img))
+    else
+        error()
+    end
+end
+
+#Finds the best shift aligning moving to fixed, possibly after an initial transformation `intial_tfm`
+function best_shift(fixed, moving, mxshift, thresh; normalization=:intensity, initial_tfm=-1)
+    if initial_tfm != -1
+        newmov = warp(moving, initial_tfm)
+        inds1, inds2 = indices(fixed), indices(newmov)
+        inds = ([intersect(x, y) for (x,y) in zip(inds1, inds2)]...)
+        fixed = view(fixed, inds...)
+        moving = newmov[inds...]
+    end
+    mms = mismatch(fixed, moving, mxshift; normalization=normalization)
+    best_i = indmin_mismatch(mms, thresh)
+    return best_i.I, ratio(mms[best_i], 0.0, Inf)
+end
+
+#rotation + shift, slow because it warps for every rotation and shift
+function slow_mm(tfm, fixed, moving, thresh, SD; initial_tfm = -1)
+    tfm = tfmx(tfm, moving, SD)
+    if initial_tfm != -1
+        tfm = tfm ∘ initial_tfm #compose with rotation already computed
+    end
+    newmov = warp(moving, tfm)
+    inds1, inds2 = indices(fixed), indices(newmov)
+    inds = ([intersect(x, y) for (x,y) in zip(inds1, inds2)]...)
+    mm = mismatch0(view(fixed, inds...), view(newmov, inds...); normalization=:pixels)
+    rslt = ratio(mm, thresh, Inf)
+    return rslt
+end
+
+#rotation + shift, fast because it uses fourier method for shift
+function fast_mm(theta, mxshift, fixed, moving, thresh, SD)
+    tfm = rot(theta, moving, SD)
+    newmov = warp(moving, tfm)
+    inds1, inds2 = indices(fixed), indices(newmov)
+    inds = ([intersect(x, y) for (x,y) in zip(inds1, inds2)]...)
+    bshft, mm = best_shift(view(fixed, inds...), newmov[inds...], mxshift, thresh; normalization=:intensity)
+    return mm
+end
+
+function qd_rigid_coarse(fixed, moving, mxshift, mxrot, minwidth_rot, SD; thresh = 0.1 * sum(abs2.(fixed[.!(isnan.(fixed))])), kwargs...)
+    f(x) = fast_mm(x, mxshift, fixed, moving, thresh, SD)
+    upper = [mxrot...]
+    lower = -upper
+    splits = ([[-x; 0.0; x] for x in mxrot]...)
+    root_coarse, x0coarse = analyze(f, splits, lower, upper; maxevals=10^4, minwidth=minwidth_rot, print_interval=100, kwargs...)
+    box_coarse = minimum(root_coarse)
+    tfmcoarse0 = rot(position(box_coarse, x0coarse), moving)
+    best_shft, mm = best_shift(fixed, moving, mxshift, thresh; normalization=:intensity, initial_tfm = tfmcoarse0)
+    tfmcoarse = Translation(best_shft) ∘ tfmcoarse0
+    return tfmcoarse, mm
+end
+
+function qd_rigid_fine(fixed, moving, mxrot, minwidth, SD; initial_tfm = -1, thresh = 0.1 * sum(abs2.(fixed[.!(isnan.(fixed))])), kwargs...)
+    f2(x) = slow_mm(x, fixed, moving, thresh, SD; initial_tfm = initial_tfm)
+    upper_shft = fill(1, ndims(fixed))
+    upper_rot = mxrot
+    upper = vcat(upper_shft, upper_rot)
+    lower = -upper
+    splits = ([[-x; 0.0; x] for x in upper]...)
+    minwidth_shfts = fill(0.01, ndims(fixed))
+    minwidth_rots = ndims(fixed) == 2 ? [0.0001;] : fill(0.0001, 3) #assume 2 or 3 dimensional input
+    minwidth = vcat(minwidth_shfts, minwidth_rots)
+    root, x0 = analyze(f2, splits, lower, upper; maxevals=10^4, minwidth=minwidth, print_interval=100, kwargs...)
+    box = minimum(root)
+    params = position(box, x0)
+    tfmfine = tfmx(position(box, x0), moving)
+    return tfmfine, value(box)
+end
+
+"""
+`tform, mm = qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot; thresh=thresh, [SD = eye], kwargs...)`
+optimizes a rigid transformation (rotation + shift) to minimize the mismatch between `fixed` and
+`moving` using the QuadDIRECT algorithm.  The algorithm is run twice: the first step uses a fourier method to speed up
+the search for the best whole-pixel shift.  The second step refines the search for sub-pixel accuracy. `kwargs...` can include any
+keyword argument that can be passed to `QuadDIRECT.analyze`. It's recommended that you pass your own stopping criteria when possible
+(i.e. `rtol`, `atol`, and/or `fvalue`).
+
+Use `SD` if your axes are not uniformly sampled, for example `SD = diagm(voxelspacing)` where `voxelspacing`
+is a vector encoding the spacing along all axes of the image. `thresh` enforces a certain amount of sum-of-squared-intensity overlap between
+the two images; with non-zero `thresh`, it is not permissible to "align" the images by shifting one entirely out of the way of the other.
+"""
+function qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD=eye(ndims(fixed)); thresh=0.1*sum(abs2.(fixed[.!(isnan.(fixed))])), kwargs...)
+    mxrot = [mxrot...]
+    print("Running coarse step\n")
+    tfm_coarse, mm_coarse = qd_rigid_coarse(fixed, moving, mxshift, mxrot, minwidth_rot, SD; thresh = thresh, kwargs...)
+    print("Running fine step\n")
+    tfm_fine, mm_fine = qd_rigid_fine(fixed, moving, mxrot./10, minwidth_rot, SD; initial_tfm = tfm_coarse, thresh = thresh, kwargs...)
+    final_tfm = tfm_fine ∘ tfm_coarse
+    return final_tfm, mm_fine
+end

--- a/test/register_fit.jl
+++ b/test/register_fit.jl
@@ -86,7 +86,7 @@ df = zeros(2)
 movinge = extrapolate(interpolate(moving, BSpline(Linear()), OnGrid()), NaN)
 for i = 1:2
     mov = TransformedArray(movinge, tfm[i])
-    df[i] = Images.meanfinite(abs.(fixed-transform(mov)), (1,2))[1]
+    df[i] = Images.meanfinite(abs.(fixed-AffineTransforms.transform(mov)), (1,2))[1]
 end
 @test minimum(df) < 1e-4*F
 

--- a/test/register_optimize.jl
+++ b/test/register_optimize.jl
@@ -1,13 +1,14 @@
 using StaticArrays, AffineTransforms, Interpolations, Base.Test
 import BlockRegistration, RegisterOptimize
 using RegisterCore, RegisterPenalty, RegisterDeformation, RegisterMismatch, RegisterFit
+using Images, CoordinateTransformations, Rotations, RegisterOptimize
 
 using RegisterTestUtilities
 
 ### Rigid registration
 fixed = sin.(linspace(0,pi,101)).*linspace(5,7,97)'
 tform = tformrotate(pi/12)
-moving = transform(fixed, tform)
+moving = AffineTransforms.transform(fixed, tform)
 tform0 = tformeye(2)
 tfrm, fval = RegisterOptimize.optimize_rigid(fixed, moving, tform0, (20,21); tol=1e-2) # print_level=5)
 tfprod = tform*tfrm
@@ -329,7 +330,7 @@ end
 ## 2D
 #note: if a is much smaller than this then it won't find the correct answer due to the mismatch normalization
 a = rand(30,30)
-b = transform(a, tformtranslate([2.0;0.0]) * tformrotate(pi/6))
+b = AffineTransforms.transform(a, tformtranslate([2.0;0.0]) * tformrotate(pi/6))
 tfm0 = tformtranslate([-2.0;0.0]) * tformrotate(-pi/6)
 #note: maxshift must be GREATER than the true shift in order to find the true shift
 tfm, mm = rotation_gridsearch(a, b, [11;11], [pi/6], [11])
@@ -339,9 +340,45 @@ tfm, mm = rotation_gridsearch(a, b, [11;11], [pi/6], [11])
 ## 3D
 #note: if a is much smaller than this then it won't find the correct answer due to the mismatch normalization
 a = rand(30,30,30)
-b = transform(a, tformtranslate([2.0;0.0;0.0]) * tformrotate([1.0;0;0], pi/4))
+b = AffineTransforms.transform(a, tformtranslate([2.0;0.0;0.0]) * tformrotate([1.0;0;0], pi/4))
 tfm0 = tformtranslate([-2.0;0.0;0.0]) * tformrotate([1.0;0;0], -pi/4)
 #note: maxshift must be GREATER than the true shift in order to find the true shift
 tfm, mm = rotation_gridsearch(a, b, [3;3;3], [pi/4, pi/4, pi/4], [5;5;5])
 @assert tfm.offset == tfm0.offset
 @assert tfm.scalefwd == tfm0.scalefwd
+
+###### Test QuadDIRECT-based rigid registration
+#2D
+moving = rand(50,50)
+tfm0 = Translation(-4.0, 5.0) ∘ recenter(RotMatrix(pi/360), center(moving)) #ground truth
+newfixed = warp(moving, tfm0)
+itp = interpolate(newfixed, BSpline(Linear()), OnGrid())
+etp = extrapolate(itp, NaN)
+fixed = etp[indices(moving)...] #often the warped array has one-too-many pixels in one or more dimensions due to extrapolation
+thresh = 0.1 * sum(abs2.(fixed[.!(isnan.(fixed))]))
+mxshift = [10;10]
+mxrot = pi/90
+minwidth_rot = [0.0002]
+SD = eye(ndims(fixed))
+
+tfm, mm = qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD; thresh=thresh, rtol = 1e-7, atol = 1e-9 * thresh)
+
+@test sum(abs.(tfm0.m - tfm.m)) < 1e-3
+
+#3D
+moving = rand(30,30,30)
+tfm0 = Translation(-1.0, 2.1,1.2) ∘ recenter(RotXYZ(pi/360, pi/180, pi/220), center(moving)) #ground truth
+newfixed = warp(moving, tfm0)
+itp = interpolate(newfixed, BSpline(Linear()), OnGrid())
+etp = extrapolate(itp, NaN)
+fixed = etp[indices(moving)...] #often the warped array has one-too-many pixels in one or more dimensions due to extrapolation
+thresh = 0.1 * sum(abs2.(fixed[.!(isnan.(fixed))]))
+mxshift = [5;5;5]
+mxrot = [pi/90; pi/90; pi/90]
+minwidth_rot = fill(0.0002, 3)
+SD = eye(ndims(fixed))
+
+tfm, mm = qd_rigid(fixed, moving, mxshift, mxrot, minwidth_rot, SD; thresh=thresh, rtol = 1e-7, atol = 1e-9 * thresh)
+
+@test mm < 1e-4
+@test sum(abs.(vcat(tfm0.m[:], tfm0.v) - vcat(RotXYZ(tfm.m)[:], tfm.v))) < 0.1


### PR DESCRIPTION
This adds a couple of options for Ipopt-based rigid registration and also introduces [QuadDIRECT](https://github.com/timholy/QuadDIRECT.jl)-based rigid registration.