### PR TITLE
Update cookbook.md

### DIFF
--- a/docs/src/cookbook.md
+++ b/docs/src/cookbook.md
@@ -99,7 +99,7 @@ Qs = Array{Any}(undef, gridsize)
 ap = AffinePenalty(nodes, first(λrange))
 
 # Now loop over each timeslice
-ϕs, λs, errs = [], [], []  # storage for results (the deformation, chosen λ, and resid for each timeslice)
+ϕs, λs, errs = AbstractDeformation[], [], []  # storage for results (the deformation, chosen λ, and resid for each timeslice)
 @showprogress 1 for tidx in axes(img, Axis{:time})
     moving = view(img, timeaxis(img)(tidx))
 


### PR DESCRIPTION
Hi, all, I was testing BlockRegistration to register two large 3d images (my image to a reference image, requiring non-linear transformation). Please let me know if anyone have any suggestions for this purpose.

Anyway, I found that `warp!` does not work with `ϕs = []'  (or Type `Any` does not work with `warp!`). 
`ϕs = AbstractDeformation[]` solves this issue.